### PR TITLE
Feat: InputText 클리어 처리 및 X 버튼 표시 핸들링

### DIFF
--- a/src/components/InputText.vue
+++ b/src/components/InputText.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref, watch } from 'vue';
 import XButton from '@/components/XButton.vue';
 
 type InputTextProps = {
@@ -7,6 +8,26 @@ type InputTextProps = {
 
 const model = defineModel<string>();
 defineProps<InputTextProps>();
+
+const isShow = ref(false);
+const isFocus = ref(false);
+
+const handleFocus = () => {
+  isFocus.value = true;
+  // InputText에 포커스가 잡혔을 때, 기존 값이 있으면 X버튼 표시
+  if (model.value !== '') isShow.value = true;
+}
+
+const handleBlur = () => {
+  isFocus.value = false;
+  isShow.value = false;
+}
+
+watch(model, () => {
+  // InputText에 포커스가 있고, 내용을 입력 중일 때 X버튼 표시
+  if (isFocus.value && model.value !== '') isShow.value = true;
+  else isShow.value = false;
+});
 </script>
 
 <template>
@@ -17,7 +38,9 @@ defineProps<InputTextProps>();
       type="text"
       autocomplete="off"
       v-model="model"
+      @focus="handleFocus"
+      @blur="handleBlur"
     />
-    <XButton />
+    <XButton v-if="isShow"/>
   </label>
 </template>

--- a/src/components/InputText.vue
+++ b/src/components/InputText.vue
@@ -9,23 +9,34 @@ type InputTextProps = {
 const model = defineModel<string>();
 defineProps<InputTextProps>();
 
-const isShow = ref(false);
-const isFocus = ref(false);
+const isShow = ref(false);  // X버튼
+const isFocus = ref(false); // InputText
 
-const handleFocus = () => {
+const handleInputFocus = () => {
   isFocus.value = true;
   // InputText에 포커스가 잡혔을 때, 기존 값이 있으면 X버튼 표시
   if (model.value !== '') isShow.value = true;
 }
 
-const handleBlur = () => {
+const handleInputBlur = (event: FocusEvent) => {
+  if (isFocus.value && model.value !== '') {
+    event.preventDefault();
+    return;
+  }
   isFocus.value = false;
+  isShow.value = false;
+}
+
+const handleXButtonClick = (event: MouseEvent) => {
+  event.stopPropagation()
+  model.value = ''; 
   isShow.value = false;
 }
 
 watch(model, () => {
   // InputText에 포커스가 있고, 내용을 입력 중일 때 X버튼 표시
   if (isFocus.value && model.value !== '') isShow.value = true;
+  else if (!isFocus.value && model.value) isShow.value = false;
   else isShow.value = false;
 });
 </script>
@@ -38,9 +49,9 @@ watch(model, () => {
       type="text"
       autocomplete="off"
       v-model="model"
-      @focus="handleFocus"
-      @blur="handleBlur"
+      @focus="handleInputFocus"
+      @blur="handleInputBlur"
     />
-    <XButton v-if="isShow"/>
+    <XButton v-if="isShow" @click="handleXButtonClick"/>
   </label>
 </template>


### PR DESCRIPTION
## PR 타입
- [x] 기능 작업
- [ ] UI 작업
- [ ] 버그 수정
- [ ] 사소한 수정
- [ ] 리팩토링
- [ ] ETC.

<br />

## 작업 내용
- X 버튼 클릭 시 InputText 클리어 처리
- InputText 내용 및 포커스 유무에 따른 X 버튼 표시 여부 핸들링

<br />

<img width="400" src="https://github.com/user-attachments/assets/343c8bbb-bebb-483d-a069-c4af8621296c" />

<img width="400" src="https://github.com/user-attachments/assets/daa571cc-e3aa-4673-b2fb-ac04c161b55b" />

<br /><br />

## 관련 issue
closed #3 

<br />

## 트러블슈팅
### InputText에 내용이 있을 때, 포커스 해제 시에도 X버튼이 계속 표시되는 문제

<img width="400" src="https://github.com/user-attachments/assets/fe54f8cc-c40d-4f78-af13-12b070c1c3f0" />

- 초기 구현 시 X 버튼을 InputText를 부모 요소로 보고 절대 위치로 조정 (InputText 위에 얹어둔 상태)
- 하지만 이 상태에서 X 버튼을 클릭하게 되면 InputText의 focus가 사라지기 때문에 조건문 처리에 의해 X 버튼이 사라지는 이슈 발생
- event.stopPropagation()을 통해 X 버튼 클릭 시 발생하는 이벤트 전파를 막아서 해결했지만 InputText에 내용이 있을 때(포커스가 없어도) X 버튼이 유지됨
- X 버튼을 디테일하게 핸들링하기 위한 추가적인 해결 필요